### PR TITLE
更准确的姿态解算

### DIFF
--- a/FTC-Explorer-V1.1/applications/FTC_IMU.cpp
+++ b/FTC-Explorer-V1.1/applications/FTC_IMU.cpp
@@ -5,10 +5,15 @@
 **********************************************************************************/
 #include "FTC_IMU.h"
 
+#define ZF 0.0f //zero float
+
 FTC_IMU imu; 
 
 FTC_IMU::FTC_IMU()
 {
+	last_gyro(ZF, ZF, ZF);
+	gravity(ZF, ZF, ACC_1G);
+	horizon(ACC_1G, ZF, ZF);
 }
 
 //IMU初始化
@@ -92,8 +97,29 @@ Vector3f FTC_IMU::Get_Accel_Ef(void)
 //余弦矩阵更新姿态
 void FTC_IMU::DCM_CF(Vector3f gyro,Vector3f acc, float deltaT)
 {
-	acc.get_rollpitch(angle);
-	acc.get_yaw(angle);
+	//余弦矩阵
+	Matrix3f dcm;
+	//来自陀螺仪的角速度的瞬时积分值
+	Vector3f sum_gyro;
+
+	//用Runge–Kutta法求得sum_gyro
+	sum_gyro = (last_gyro + gyro) * 0.5 * deltaT;
+	//更新上次的角速度
+	last_gyro = gyro;
+
+	//构建余弦矩阵
+	dcm.from_euler(sum_gyro);
+
+	//求得重力加速度旋转至BCS（Body Coordinate System）的向量
+	gravity = dcm * gravity;
+	//求得水平方向加速旋转至BCS的向量
+	horizon = dcm * horizon;
+	//将旋转后的重力加速度与加速度融合
+	gravity = CF_1st(gravity, acc, CF_Factor_Cal(deltaT, GYRO_CF_TAU));
+
+	//求得欧拉角
+	gravity.get_rollpitch(angle);
+	horizon.get_yaw(angle);
 }
 
 #define Kp 2.0f        //加速度权重，越大则向加速度测量值收敛越快

--- a/FTC-Explorer-V1.1/applications/FTC_IMU.h
+++ b/FTC-Explorer-V1.1/applications/FTC_IMU.h
@@ -36,6 +36,8 @@ private:
 
 	Quaternion Q;
 
+	Vector3f last_gyro, gravity, horizon;
+	
 	int32_t accRatio;
 
 	float getDeltaT(uint32_t time);


### PR DESCRIPTION
利用加速度计和陀螺仪获取姿态；
解算思路：根据陀螺仪得到的角度增量计算方向余弦矩阵，利用该矩阵将GCS变换至BCS，互补滤波加速度计与陀螺仪计算BCS结果更新BCS中重力加速度的坐标，根据BCS求得欧拉角；
IMU新增辅助成员变量last_gyro, gravity, horizon；
Task 3 完成。